### PR TITLE
Fix 1 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-core</artifactId>
-            <version>2.5.25</version>
+            <version>6.3.0.2</version>
         </dependency>
         <!--vulnerable dependency end-->
 


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Tue, 23 Jan 2024 10:27:15 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | app/pom.xml | org.apache.struts_struts2-core | [CVE-2023-50164](https://nvd.nist.gov/vuln/detail/CVE-2023-50164) | 9.8 | fixed in 6.3.0.2, 2.5.33 | An attacker can manipulate file upload params to enable paths traversal and under some circumstances this can lead to uploading a malicious file which can be used to perform Remote Code Execution. Users are recommended to upgrade to versions Struts 2.5.33 or Struts 6.3.0.2 or greater tou00a0fix this issue. 
critical | app/pom.xml | org.apache.struts_struts2-core | [CVE-2020-17530](https://nvd.nist.gov/vuln/detail/CVE-2020-17530) | 9.8 | fixed in 2.5.30 | Forced OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution. Affected software : Apache Struts 2.0.0 - Struts 2.5.25.
critical | app/pom.xml | org.apache.struts_struts2-core | [CVE-2021-31805](https://nvd.nist.gov/vuln/detail/CVE-2021-31805) | 9.8 | fixed in 2.5.30 | The fix issued for CVE-2020-17530 was incomplete. So from Apache Struts 2.0.0 to 2.5.29, still some of the tag’s attributes could perform a double evaluation if a developer applied forced OGNL evaluation by using the %{...} syntax. Using forced OGNL evaluation on untrusted user input can lead to a Remote Code Execution and security degradation.
high | app/pom.xml | org.apache.struts_struts2-core | [CVE-2023-41835](https://nvd.nist.gov/vuln/detail/CVE-2023-41835) | 7.5 | fixed in 6.3.0.1, 2.5.32 | When a Multipart request is performed but some of the fields exceed the maxStringLengthu00a0 limit, the upload files will remain in struts.multipart.saveDiru00a0 even if the request has been denied. Users are recommended to upgrade to versions Struts 2.5.32 or 6.1.2.2 or Struts 6.3.0.1 or greater, which fixe this issue.
high | app/pom.xml | org.apache.struts_struts2-core | [CVE-2023-34396](https://nvd.nist.gov/vuln/detail/CVE-2023-34396) | 7.5 | fixed in 6.1.2.1, 2.5.31 | Allocation of Resources Without Limits or Throttling vulnerability in Apache Software Foundation Apache Struts.This issue affects Apache Struts: through 2.5.30, through 6.1.2.  Upgrade to Struts 2.5.31 or 6.1.2.1 or greater   
medium | app/pom.xml | org.apache.struts_struts2-core | [CVE-2023-34149](https://nvd.nist.gov/vuln/detail/CVE-2023-34149) | 6.5 | fixed in 6.1.2.1, 2.5.31 | Allocation of Resources Without Limits or Throttling vulnerability in Apache Software Foundation Apache Struts.This issue affects Apache Struts: through 2.5.30, through 6.1.2.  Upgrade to Struts 2.5.31 or 6.1.2.1 or greater.   
